### PR TITLE
fix(backend/nats): fix `ensureStream` error

### DIFF
--- a/backend/nats/jetstream.go
+++ b/backend/nats/jetstream.go
@@ -282,11 +282,11 @@ func (js *jetStream) ensureStream(ctx context.Context) error {
 	info, err := js.ctx.StreamInfo(js.stream)
 	if err == nil {
 		if info.Config.Name != js.stream {
-			return fmt.Errorf("%w: stream name mismatch: %q != %q", ErrConsumerExists, info.Config.Name, js.stream)
+			return fmt.Errorf("%w: stream name mismatch: %q != %q", ErrStreamExists, info.Config.Name, js.stream)
 		}
 
 		if len(info.Config.Subjects) != 1 || info.Config.Subjects[0] != "*" {
-			return fmt.Errorf("%w: subjects mismatch: %v != %v", ErrConsumerExists, info.Config.Subjects, []string{"*"})
+			return fmt.Errorf("%w: subjects mismatch: %v != %v", ErrStreamExists, info.Config.Subjects, []string{"*"})
 		}
 
 		return nil


### PR DESCRIPTION
change the return from  `ErrConsumerExists` to `ErrStreamExists` in the Jetstream driver `ensureStream` method

closes #115