### PR TITLE
feat(options.go): add RawSubjectFunc

### DIFF
--- a/backend/nats/options.go
+++ b/backend/nats/options.go
@@ -121,16 +121,22 @@ func LoadBalancer(serviceName string) EventBusOption {
 	})
 }
 
+// RawSubjectFunc returns an option that specifies how the NATS subjects for
+// event names are generated without any modifications.
+func RawSubjectFunc(fn func(eventName string) string) EventBusOption {
+	return func(bus *EventBus) {
+		bus.subjectFunc = fn
+	}
+}
+
 // SubjectFunc returns an option that specifies how the NATS subjects for event
 // names are generated. Any "." in the subject are replaced by "_".
 //
 // By default, a subject is the event name with "." replaced by "_".
 func SubjectFunc(fn func(eventName string) string) EventBusOption {
-	return func(bus *EventBus) {
-		bus.subjectFunc = func(eventName string) string {
+	return RawSubjectFunc(func(eventName string) string {
 			return replaceDots(fn(eventName))
-		}
-	}
+	})
 }
 
 // SubjectFunc returns an option that specifies how the NATS subjects for event
@@ -139,14 +145,6 @@ func SubjectPrefix(prefix string) EventBusOption {
 	return SubjectFunc(func(eventName string) string {
 		return prefix + eventName
 	})
-}
-
-// RawSubjectFunc returns an option that specifies how the NATS subjects for
-// event names are generated without any modifications.
-func RawSubjectFunc(fn func(eventName string) string) EventBusOption {
-	return func(bus *EventBus) {
-		bus.subjectFunc = fn
-	}
 }
 
 // PullTimeout returns an option that limits the Duration an event bus tries to

--- a/backend/nats/options.go
+++ b/backend/nats/options.go
@@ -141,6 +141,14 @@ func SubjectPrefix(prefix string) EventBusOption {
 	})
 }
 
+// RawSubjectFunc returns an option that specifies how the NATS subjects for
+// event names are generated without any modifications.
+func RawSubjectFunc(fn func(eventName string) string) EventBusOption {
+	return func(bus *EventBus) {
+		bus.subjectFunc = fn
+	}
+}
+
 // PullTimeout returns an option that limits the Duration an event bus tries to
 // push an event into a subscribed event channel. When the pull timeout is
 // exceeded, the event gets dropped and a warning is logged. Default is the


### PR DESCRIPTION
In some cases, you may want to use subjects with a dot. This can be useful for:

- grouping messages
- per-topic authorization
- wildcards provided by NATS ('+', '>')

I see no reason why using topics with dots should be forbidden.