### PR TITLE
Support pre-created event tables in the Postgres backend (supersedes #341)

### DIFF
--- a/backend/postgres/store.go
+++ b/backend/postgres/store.go
@@ -87,6 +87,8 @@ func Table(name string) EventStoreOption {
 	}
 }
 
+var ErrTableDoesNotExist = errors.New("table does not exist")
+
 // NewEventStore returns a new PostgreSQL event store. If not otherwise
 // specified using the URL() option, os.Getenv("POSTGRES_EVENTSTORE") is used as
 // the connection string.
@@ -142,12 +144,18 @@ func (store *EventStore) connectOnce(ctx context.Context) error {
 			return
 		}
 
-		if err = store.createTable(ctx); err != nil {
-			return
-		}
+		if err = store.validateTableSchema(ctx); err != nil {
+			if errors.Is(err, ErrTableDoesNotExist) {
+				if err = store.createTable(ctx); err != nil {
+					return
+				}
 
-		if err = store.createIndexes(ctx); err != nil {
-			return
+				if err = store.createIndexes(ctx); err != nil {
+					return
+				}
+			} else {
+				return
+			}
 		}
 	})
 	return err
@@ -216,6 +224,88 @@ func (store *EventStore) useDatabase(ctx context.Context) error {
 		return fmt.Errorf("connect to postgres: %w [url=%s]", err, cfg.ConnString())
 	}
 	store.pool = pool
+
+	return nil
+}
+
+func (store *EventStore) validateTableSchema(ctx context.Context) error {
+	builder := squirrel.
+		Select("column_name", "data_type", "udt_name").
+		From("information_schema.columns").
+		Where(squirrel.Eq{"table_name": store.table}).
+		OrderBy("ordinal_position").
+		PlaceholderFormat(squirrel.Dollar)
+
+	sql, args, err := builder.ToSql()
+	if err != nil {
+		return fmt.Errorf("build sql: %w", err)
+	}
+
+	type colInfo struct {
+		name     string
+		dataType string
+		udtName  string
+	}
+
+	rows, _ := store.pool.Query(ctx, sql, args...)
+	cols, err := pgx.CollectRows(rows, func(row pgx.CollectableRow) (colInfo, error) {
+		var c colInfo
+		err := row.Scan(&c.name, &c.dataType, &c.udtName)
+		return c, err
+	})
+	if err != nil {
+		return fmt.Errorf("collect column info for table %q: %w", store.table, err)
+	}
+
+	if len(cols) == 0 {
+		return fmt.Errorf("table %q does not exist: %w", store.table, ErrTableDoesNotExist)
+	}
+
+	columns := make(map[string]colInfo, len(cols))
+	for _, c := range cols {
+		columns[c.name] = c
+	}
+
+	expected := map[string]string{
+		columnID:               "uuid",
+		columnName:             "character varying",
+		columnTime:             "bigint",
+		columnAggregateID:      "uuid",
+		columnAggregateName:    "character varying",
+		columnAggregateVersion: "integer",
+		columnData:             "USER-DEFINED",
+	}
+
+	var missing []string
+	var typeMismatches []string
+	for col, expectedType := range expected {
+		info, ok := columns[col]
+		if !ok {
+			missing = append(missing, fmt.Sprintf("%q", col))
+			continue
+		}
+		// For jsonb, Postgres reports data_type as "USER-DEFINED" and udt_name as "jsonb".
+		actualType := info.dataType
+		if actualType == "USER-DEFINED" {
+			actualType = info.udtName
+		}
+		checkType := expectedType
+		if checkType == "USER-DEFINED" {
+			checkType = "jsonb"
+		}
+		if actualType != checkType {
+			typeMismatches = append(typeMismatches, fmt.Sprintf("column %q should have type %q but has type %q", col, checkType, actualType))
+		}
+	}
+
+	if len(missing) > 0 || len(typeMismatches) > 0 {
+		var problems []string
+		if len(missing) > 0 {
+			problems = append(problems, fmt.Sprintf("missing columns: %s", strings.Join(missing, ", ")))
+		}
+		problems = append(problems, typeMismatches...)
+		return fmt.Errorf("table %q schema mismatch: %s", store.table, strings.Join(problems, "; "))
+	}
 
 	return nil
 }

--- a/backend/postgres/store.go
+++ b/backend/postgres/store.go
@@ -112,6 +112,32 @@ var eventTableColumns = []struct {
 // NewEventStore returns a new PostgreSQL event store. If not otherwise
 // specified using the URL() option, os.Getenv("POSTGRES_EVENTSTORE") is used as
 // the connection string.
+//
+// On connect, the store looks up the event table (see the Table option). If
+// the table does not exist, the store creates it together with its indexes,
+// which requires the CREATE privilege on the schema. If the table already
+// exists — for example because it was created by a migration tool using a more
+// privileged role — the store instead validates that the table matches the
+// following schema and creates any missing indexes if permitted:
+//
+//	CREATE TABLE events (
+//		id UUID PRIMARY KEY NOT NULL,
+//		name VARCHAR(255) NOT NULL,
+//		time BIGINT NOT NULL,
+//		aggregate_id UUID,
+//		aggregate_name VARCHAR(255),
+//		aggregate_version INTEGER,
+//		data JSONB
+//	);
+//
+//	CREATE INDEX goes_name ON events (name);
+//	CREATE INDEX goes_time ON events (time);
+//	CREATE UNIQUE INDEX goes_aggregate ON events (aggregate_id, aggregate_name, aggregate_version);
+//
+// TEXT columns are accepted in place of VARCHAR. The UNIQUE index on
+// (aggregate_id, aggregate_name, aggregate_version) is required because it
+// enforces optimistic concurrency for aggregates: Connect fails if it is
+// missing and cannot be created with the privileges of the connected role.
 func NewEventStore(enc codec.Encoding, opts ...EventStoreOption) *EventStore {
 	store := &EventStore{
 		enc:           enc,
@@ -165,18 +191,19 @@ func (store *EventStore) connectOnce(ctx context.Context) error {
 		}
 
 		if err = store.validateTableSchema(ctx); err != nil {
-			if errors.Is(err, ErrTableDoesNotExist) {
-				if err = store.createTable(ctx); err != nil {
-					return
-				}
-
-				if err = store.createIndexes(ctx); err != nil {
-					return
-				}
-			} else {
+			if !errors.Is(err, ErrTableDoesNotExist) {
 				return
 			}
+
+			if err = store.createTable(ctx); err != nil {
+				return
+			}
+
+			err = store.createIndexes(ctx)
+			return
 		}
+
+		err = store.ensureIndexes(ctx)
 	})
 	return err
 }
@@ -316,6 +343,147 @@ func (store *EventStore) createTable(ctx context.Context) error {
 	return nil
 }
 
+// indexSpec describes an index that the event store requires on the event
+// table.
+type indexSpec struct {
+	name   string
+	fields []string
+	unique bool
+}
+
+// requiredIndexes are the indexes the event store requires on the event table.
+// The unique index enforces optimistic concurrency for aggregates: without it,
+// concurrently inserted events with conflicting aggregate versions would not
+// fail.
+var requiredIndexes = []indexSpec{
+	{
+		name:   "goes_name",
+		fields: []string{columnName},
+	},
+	{
+		name:   "goes_time",
+		fields: []string{columnTime},
+	},
+	{
+		name:   "goes_aggregate",
+		fields: []string{columnAggregateID, columnAggregateName, columnAggregateVersion},
+		unique: true,
+	},
+}
+
+// tableIndex describes an index that exists on the event table.
+type tableIndex struct {
+	unique  bool
+	keyCols int16
+	columns []string
+}
+
+// satisfies reports whether the index provides what the required index spec
+// demands. A unique requirement is only satisfied by a unique index over
+// exactly the required columns (in any order), because a unique index over
+// more columns enforces a weaker constraint. A non-unique requirement is
+// satisfied by any index whose leading columns are the required ones.
+func (idx tableIndex) satisfies(spec indexSpec) bool {
+	if len(idx.columns) != int(idx.keyCols) {
+		// The index has expression keys and cannot be matched against plain
+		// column requirements.
+		return false
+	}
+
+	if spec.unique {
+		if !idx.unique || len(idx.columns) != len(spec.fields) {
+			return false
+		}
+		for _, field := range spec.fields {
+			if !slices.Contains(idx.columns, field) {
+				return false
+			}
+		}
+		return true
+	}
+
+	if len(idx.columns) < len(spec.fields) {
+		return false
+	}
+	return slices.Equal(idx.columns[:len(spec.fields)], spec.fields)
+}
+
+// ensureIndexes checks that an existing event table provides the required
+// indexes. Missing indexes are created if the connected role has the required
+// privileges (the behavior of previous releases). Otherwise, an error is
+// returned that includes the DDL to create them manually.
+func (store *EventStore) ensureIndexes(ctx context.Context) error {
+	missing, err := store.missingIndexes(ctx)
+	if err != nil {
+		return err
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+
+	createErr := store.createIndexes(ctx)
+
+	if missing, err = store.missingIndexes(ctx); err != nil {
+		return err
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+
+	names := make([]string, len(missing))
+	ddl := make([]string, len(missing))
+	for i, spec := range missing {
+		names[i] = fmt.Sprintf("%q", spec.name)
+		ddl[i] = indexSQL(spec.name, store.table, spec.fields, spec.unique)
+	}
+
+	if createErr != nil {
+		return fmt.Errorf(
+			"table %q is missing required indexes (%s): %w\ncreate them manually:\n%s",
+			store.table, strings.Join(names, ", "), createErr, strings.Join(ddl, ";\n"),
+		)
+	}
+
+	return fmt.Errorf(
+		"table %q has indexes named %s that do not match the required definitions:\n%s",
+		store.table, strings.Join(names, ", "), strings.Join(ddl, ";\n"),
+	)
+}
+
+// missingIndexes returns the required indexes that no existing index of the
+// event table satisfies.
+func (store *EventStore) missingIndexes(ctx context.Context) ([]indexSpec, error) {
+	// Key columns of every valid, non-partial index of the table, resolved
+	// through the search_path like the store's queries. Expression keys have
+	// no matching pg_attribute row and are filtered out of the column array;
+	// satisfies() detects this via indnkeyatts.
+	const query = `
+		SELECT i.indisunique, i.indnkeyatts, COALESCE(array_agg(a.attname ORDER BY k.ord) FILTER (WHERE a.attname IS NOT NULL), '{}')
+		FROM pg_catalog.pg_index i
+		CROSS JOIN LATERAL unnest(i.indkey::int2[]) WITH ORDINALITY AS k(attnum, ord)
+		LEFT JOIN pg_catalog.pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = k.attnum
+		WHERE i.indrelid = to_regclass($1) AND i.indisvalid AND i.indpred IS NULL AND k.ord <= i.indnkeyatts
+		GROUP BY i.indexrelid, i.indisunique, i.indnkeyatts`
+
+	rows, _ := store.pool.Query(ctx, query, store.table)
+	indexes, err := pgx.CollectRows(rows, func(row pgx.CollectableRow) (tableIndex, error) {
+		var idx tableIndex
+		err := row.Scan(&idx.unique, &idx.keyCols, &idx.columns)
+		return idx, err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("collect index info for table %q: %w", store.table, err)
+	}
+
+	var missing []indexSpec
+	for _, spec := range requiredIndexes {
+		if !slices.ContainsFunc(indexes, func(idx tableIndex) bool { return idx.satisfies(spec) }) {
+			missing = append(missing, spec)
+		}
+	}
+	return missing, nil
+}
+
 func (store *EventStore) createIndexes(ctx context.Context) error {
 	tx, err := store.pool.Begin(ctx)
 	if err != nil {
@@ -323,27 +491,7 @@ func (store *EventStore) createIndexes(ctx context.Context) error {
 	}
 	defer tx.Rollback(ctx)
 
-	indexes := []struct {
-		name   string
-		fields []string
-		unique bool
-	}{
-		{
-			name:   "goes_name",
-			fields: []string{columnName},
-		},
-		{
-			name:   "goes_time",
-			fields: []string{columnTime},
-		},
-		{
-			name:   "goes_aggregate",
-			fields: []string{columnAggregateID, columnAggregateName, columnAggregateVersion},
-			unique: true,
-		},
-	}
-
-	for _, idx := range indexes {
+	for _, idx := range requiredIndexes {
 		schema := indexSQL(idx.name, store.table, idx.fields, idx.unique)
 		if _, err := tx.Exec(ctx, schema); err != nil {
 			return fmt.Errorf("create %q index: %w [fields=%v]", idx.name, err, idx.fields)

--- a/backend/postgres/store.go
+++ b/backend/postgres/store.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -87,7 +88,26 @@ func Table(name string) EventStoreOption {
 	}
 }
 
+// ErrTableDoesNotExist is returned when the configured event table does not
+// exist in the connected database.
 var ErrTableDoesNotExist = errors.New("table does not exist")
+
+// eventTableColumns are the required columns of the event table together with
+// their accepted types, as reported by format_type. The first type of each
+// column is the one the store itself creates; any additional types are
+// functionally equivalent alternatives that pre-created tables may use.
+var eventTableColumns = []struct {
+	name  string
+	types []string
+}{
+	{columnID, []string{"uuid"}},
+	{columnName, []string{"character varying", "text"}},
+	{columnTime, []string{"bigint"}},
+	{columnAggregateID, []string{"uuid"}},
+	{columnAggregateName, []string{"character varying", "text"}},
+	{columnAggregateVersion, []string{"integer"}},
+	{columnData, []string{"jsonb"}},
+}
 
 // NewEventStore returns a new PostgreSQL event store. If not otherwise
 // specified using the URL() option, os.Getenv("POSTGRES_EVENTSTORE") is used as
@@ -229,28 +249,26 @@ func (store *EventStore) useDatabase(ctx context.Context) error {
 }
 
 func (store *EventStore) validateTableSchema(ctx context.Context) error {
-	builder := squirrel.
-		Select("column_name", "data_type", "udt_name").
-		From("information_schema.columns").
-		Where(squirrel.Eq{"table_name": store.table}).
-		OrderBy("ordinal_position").
-		PlaceholderFormat(squirrel.Dollar)
-
-	sql, args, err := builder.ToSql()
-	if err != nil {
-		return fmt.Errorf("build sql: %w", err)
-	}
+	// Resolve the table through to_regclass so that the lookup follows the
+	// same rules as the store's queries: the search_path decides which schema
+	// the unqualified table name refers to, and schema-qualified names are
+	// honored. Filtering information_schema.columns by table name alone would
+	// match same-named tables in unrelated schemas.
+	const query = `
+		SELECT a.attname, format_type(a.atttypid, NULL)
+		FROM pg_catalog.pg_attribute a
+		WHERE a.attrelid = to_regclass($1) AND a.attnum > 0 AND NOT a.attisdropped
+		ORDER BY a.attnum`
 
 	type colInfo struct {
 		name     string
 		dataType string
-		udtName  string
 	}
 
-	rows, _ := store.pool.Query(ctx, sql, args...)
+	rows, _ := store.pool.Query(ctx, query, store.table)
 	cols, err := pgx.CollectRows(rows, func(row pgx.CollectableRow) (colInfo, error) {
 		var c colInfo
-		err := row.Scan(&c.name, &c.dataType, &c.udtName)
+		err := row.Scan(&c.name, &c.dataType)
 		return c, err
 	})
 	if err != nil {
@@ -261,40 +279,21 @@ func (store *EventStore) validateTableSchema(ctx context.Context) error {
 		return fmt.Errorf("table %q does not exist: %w", store.table, ErrTableDoesNotExist)
 	}
 
-	columns := make(map[string]colInfo, len(cols))
+	columns := make(map[string]string, len(cols))
 	for _, c := range cols {
-		columns[c.name] = c
-	}
-
-	expected := map[string]string{
-		columnID:               "uuid",
-		columnName:             "character varying",
-		columnTime:             "bigint",
-		columnAggregateID:      "uuid",
-		columnAggregateName:    "character varying",
-		columnAggregateVersion: "integer",
-		columnData:             "USER-DEFINED",
+		columns[c.name] = c.dataType
 	}
 
 	var missing []string
 	var typeMismatches []string
-	for col, expectedType := range expected {
-		info, ok := columns[col]
+	for _, col := range eventTableColumns {
+		actualType, ok := columns[col.name]
 		if !ok {
-			missing = append(missing, fmt.Sprintf("%q", col))
+			missing = append(missing, fmt.Sprintf("%q", col.name))
 			continue
 		}
-		// For jsonb, Postgres reports data_type as "USER-DEFINED" and udt_name as "jsonb".
-		actualType := info.dataType
-		if actualType == "USER-DEFINED" {
-			actualType = info.udtName
-		}
-		checkType := expectedType
-		if checkType == "USER-DEFINED" {
-			checkType = "jsonb"
-		}
-		if actualType != checkType {
-			typeMismatches = append(typeMismatches, fmt.Sprintf("column %q should have type %q but has type %q", col, checkType, actualType))
+		if !slices.Contains(col.types, actualType) {
+			typeMismatches = append(typeMismatches, fmt.Sprintf("column %q should have type %q but has type %q", col.name, col.types[0], actualType))
 		}
 	}
 

--- a/backend/postgres/store_test.go
+++ b/backend/postgres/store_test.go
@@ -4,51 +4,104 @@ package postgres_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sync/atomic"
 	"testing"
-	"time"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/modernice/goes/persistence/model"
 	"github.com/modernice/goes/backend/postgres"
 	"github.com/modernice/goes/backend/testing/eventstoretest"
 	"github.com/modernice/goes/codec"
 	"github.com/modernice/goes/event"
+	"github.com/modernice/goes/event/test"
 )
 
 func TestEventStore(t *testing.T) {
 	eventstoretest.Run(t, "postgres", func(enc codec.Encoding) event.Store {
-		time.Sleep(60 * time.Millisecond) // Wait for previous connections to close
 		return postgres.NewEventStore(enc, postgres.URL(fmt.Sprintf("%s?pool_max_conn_lifetime=50ms", os.Getenv("POSTGRES_EVENTSTORE"))), postgres.Database(nextDatabase()))
 	})
 }
 
-func TestEventStoreWithPool(t *testing.T) {
-	eventstoretest.Run(t, "postgres", func(enc codec.Encoding) event.Store {
-		ctx := context.Background()
+func TestConnect_NewEventStoreWithPoolOption(t *testing.T) {
+	database := preCreateDatabase(t)
 
-		pool, err := pgxpool.New(ctx, os.Getenv("POSTGRES_EVENTSTORE"))
-		if err != nil {
-			t.Fatalf("Failed to create bootstrapping connection to server: %v", err)
-		}
+	ctx := context.Background()
 
-		database := nextDatabase()
-		_, err = pool.Exec(ctx, fmt.Sprintf("CREATE DATABASE %s", database))
-		if err != nil {
-			pool.Close()
-			t.Fatalf("create %q database: %v", database, err)
-		}
-		pool.Close()
+	pool, err := pgxpool.New(ctx, fmt.Sprintf("%s/%s", os.Getenv("POSTGRES_EVENTSTORE"), database))
+	if err != nil {
+		t.Fatalf("Failed to create connection to database %q: %v", database, err)
+	}
+	defer pool.Close()
 
-		time.Sleep(60 * time.Millisecond) // Wait for previous connections to close
-		pool, err = pgxpool.New(ctx, fmt.Sprintf("%s/%s?pool_max_conn_lifetime=50ms", os.Getenv("POSTGRES_EVENTSTORE"), database))
-		if err != nil {
-			t.Fatalf("Failed to create connection to database %q: %v", database, err)
-		}
+	store := postgres.NewEventStore(test.NewEncoder(), postgres.Pool(pool))
+	if err := store.Connect(ctx); err != nil {
+		t.Fatalf("Failed to connect store: %v", err)
+	}
 
-		return postgres.NewEventStore(enc, postgres.Pool(pool))
-	})
+	// Sanity check that the store is working
+	_, err = store.Find(ctx, uuid.New())
+	if !errors.Is(err, model.ErrNotFound) {
+		t.Fatalf("Find returned unexpected error: %v", err)
+	}
+}
+
+func TestConnect_ExistingTableWithCorrectSchema(t *testing.T) {
+	database := preCreateDatabaseAndTable(t, `CREATE TABLE %s (
+		id UUID PRIMARY KEY NOT NULL,
+		name VARCHAR(255) NOT NULL,
+		time BIGINT NOT NULL,
+		aggregate_id UUID,
+		aggregate_name VARCHAR(255),
+		aggregate_version INTEGER,
+		data JSONB
+	)`)
+
+	ctx := context.Background()
+
+	pool, err := pgxpool.New(ctx, fmt.Sprintf("%s/%s", os.Getenv("POSTGRES_EVENTSTORE"), database))
+	if err != nil {
+		t.Fatalf("Failed to create connection to database %q: %v", database, err)
+	}
+	defer pool.Close()
+
+	store := postgres.NewEventStore(test.NewEncoder(), postgres.Pool(pool))
+	if err := store.Connect(ctx); err != nil {
+		t.Fatalf("Failed to connect store: %v", err)
+	}
+}
+
+func TestConnect_ExistingTableWithInvalidSchema(t *testing.T) {
+	database := preCreateDatabaseAndTable(t, `CREATE TABLE %s (
+		id UUID PRIMARY KEY NOT NULL,
+		name VARCHAR(255) NOT NULL,
+		time BIGINT NOT NULL,
+		aggregate_id BIGINT,
+		aggregate_name VARCHAR(255),
+		aggregate_version INTEGER
+	)`)
+
+	ctx := context.Background()
+
+	pool, err := pgxpool.New(ctx, fmt.Sprintf("%s/%s", os.Getenv("POSTGRES_EVENTSTORE"), database))
+	if err != nil {
+		t.Fatalf("Failed to create connection to database %q: %v", database, err)
+	}
+	defer pool.Close()
+
+	store := postgres.NewEventStore(test.NewEncoder(), postgres.Pool(pool))
+	err = store.Connect(ctx)
+	if err == nil {
+		t.Fatal("Did not fail to Connect when existing table has invalid schema")
+	}
+
+	expectedError := `table "events" schema mismatch: missing columns: "data"; column "aggregate_id" should have type "uuid" but has type "bigint"`
+	if err.Error() != expectedError {
+		t.Fatalf("Connect returned unexpected error: %v", err)
+	}
 }
 
 var databaseN uint64
@@ -56,4 +109,44 @@ var databaseN uint64
 func nextDatabase() string {
 	n := atomic.AddUint64(&databaseN, 1)
 	return fmt.Sprintf("goes_%d", n)
+}
+
+func preCreateDatabase(t *testing.T) string {
+	ctx := context.Background()
+
+	pool, err := pgxpool.New(ctx, os.Getenv("POSTGRES_EVENTSTORE"))
+	if err != nil {
+		t.Fatalf("Failed to create bootstrapping connection to server: %v", err)
+	}
+	defer pool.Close()
+
+	database := nextDatabase()
+
+	_, err = pool.Exec(ctx, fmt.Sprintf("CREATE DATABASE %s", database))
+	if err != nil {
+		t.Fatalf("create %q database: %v", database, err)
+	}
+
+	return database
+}
+
+func preCreateDatabaseAndTable(t *testing.T, createTableFormatString string) string {
+	database := preCreateDatabase(t)
+
+	ctx := context.Background()
+
+	pool, err := pgxpool.New(ctx, fmt.Sprintf("%s/%s", os.Getenv("POSTGRES_EVENTSTORE"), database))
+	if err != nil {
+		t.Fatalf("Failed to create bootstrapping connection to server: %v", err)
+	}
+	defer pool.Close()
+
+	const tableName = "events"
+
+	_, err = pool.Exec(ctx, fmt.Sprintf(createTableFormatString, tableName))
+	if err != nil {
+		t.Fatalf("create %q table in database %q: %v", tableName, database, err)
+	}
+
+	return database
 }

--- a/backend/postgres/store_test.go
+++ b/backend/postgres/store_test.go
@@ -6,18 +6,20 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
+	"strings"
 	"sync/atomic"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/modernice/goes/persistence/model"
 	"github.com/modernice/goes/backend/postgres"
 	"github.com/modernice/goes/backend/testing/eventstoretest"
 	"github.com/modernice/goes/codec"
 	"github.com/modernice/goes/event"
 	"github.com/modernice/goes/event/test"
+	"github.com/modernice/goes/persistence/model"
 )
 
 func TestEventStore(t *testing.T) {
@@ -104,6 +106,137 @@ func TestConnect_ExistingTableWithInvalidSchema(t *testing.T) {
 	}
 }
 
+const correctTableSQL = `CREATE TABLE %s (
+	id UUID PRIMARY KEY NOT NULL,
+	name VARCHAR(255) NOT NULL,
+	time BIGINT NOT NULL,
+	aggregate_id UUID,
+	aggregate_name VARCHAR(255),
+	aggregate_version INTEGER,
+	data JSONB
+)`
+
+func TestConnect_ExistingTableWithMissingIndexes(t *testing.T) {
+	database := preCreateDatabaseAndTable(t, correctTableSQL)
+
+	ctx := context.Background()
+
+	pool, err := pgxpool.New(ctx, fmt.Sprintf("%s/%s", os.Getenv("POSTGRES_EVENTSTORE"), database))
+	if err != nil {
+		t.Fatalf("Failed to create connection to database %q: %v", database, err)
+	}
+	defer pool.Close()
+
+	store := postgres.NewEventStore(test.NewEncoder(), postgres.Pool(pool))
+	if err := store.Connect(ctx); err != nil {
+		t.Fatalf("Failed to connect store: %v", err)
+	}
+
+	// The connected role is allowed to create indexes, so Connect must have
+	// created the missing ones.
+	var unique bool
+	if err := pool.QueryRow(ctx, "SELECT indisunique FROM pg_index WHERE indexrelid = 'goes_aggregate'::regclass").Scan(&unique); err != nil {
+		t.Fatalf("goes_aggregate index was not created: %v", err)
+	}
+	if !unique {
+		t.Fatal("goes_aggregate index is not unique")
+	}
+}
+
+func TestConnect_ExistingTableWithConflictingIndex(t *testing.T) {
+	database := preCreateDatabaseAndTable(t, correctTableSQL)
+
+	ctx := context.Background()
+
+	pool, err := pgxpool.New(ctx, fmt.Sprintf("%s/%s", os.Getenv("POSTGRES_EVENTSTORE"), database))
+	if err != nil {
+		t.Fatalf("Failed to create connection to database %q: %v", database, err)
+	}
+	defer pool.Close()
+
+	// Occupy the name of the required unique index with an incompatible
+	// definition. CREATE INDEX IF NOT EXISTS cannot fix this, so Connect must
+	// fail.
+	if _, err := pool.Exec(ctx, "CREATE INDEX goes_aggregate ON events (aggregate_id)"); err != nil {
+		t.Fatalf("create conflicting index: %v", err)
+	}
+
+	store := postgres.NewEventStore(test.NewEncoder(), postgres.Pool(pool))
+	err = store.Connect(ctx)
+	if err == nil {
+		t.Fatal("Did not fail to Connect when an existing index conflicts with the required definition")
+	}
+
+	if !strings.Contains(err.Error(), `"goes_aggregate"`) {
+		t.Fatalf("Connect returned unexpected error: %v", err)
+	}
+}
+
+func TestConnect_RestrictedUser(t *testing.T) {
+	database := preCreateDatabaseAndTable(t, correctTableSQL)
+
+	ctx := context.Background()
+
+	admin, err := pgxpool.New(ctx, fmt.Sprintf("%s/%s", os.Getenv("POSTGRES_EVENTSTORE"), database))
+	if err != nil {
+		t.Fatalf("Failed to create connection to database %q: %v", database, err)
+	}
+	defer admin.Close()
+
+	for _, stmt := range []string{
+		"CREATE INDEX goes_name ON events (name)",
+		"CREATE INDEX goes_time ON events (time)",
+		"CREATE UNIQUE INDEX goes_aggregate ON events (aggregate_id, aggregate_name, aggregate_version)",
+	} {
+		if _, err := admin.Exec(ctx, stmt); err != nil {
+			t.Fatalf("%s: %v", stmt, err)
+		}
+	}
+
+	user := createRestrictedUser(t, admin, database)
+
+	pool := connectAs(t, user, database)
+	defer pool.Close()
+
+	store := postgres.NewEventStore(test.NewEncoder(), postgres.Pool(pool))
+	if err := store.Connect(ctx); err != nil {
+		t.Fatalf("Connect must not require DDL privileges when the table and indexes exist: %v", err)
+	}
+
+	// Sanity check that the store is working
+	_, err = store.Find(ctx, uuid.New())
+	if !errors.Is(err, model.ErrNotFound) {
+		t.Fatalf("Find returned unexpected error: %v", err)
+	}
+}
+
+func TestConnect_RestrictedUserMissingUniqueIndex(t *testing.T) {
+	database := preCreateDatabaseAndTable(t, correctTableSQL)
+
+	ctx := context.Background()
+
+	admin, err := pgxpool.New(ctx, fmt.Sprintf("%s/%s", os.Getenv("POSTGRES_EVENTSTORE"), database))
+	if err != nil {
+		t.Fatalf("Failed to create connection to database %q: %v", database, err)
+	}
+	defer admin.Close()
+
+	user := createRestrictedUser(t, admin, database)
+
+	pool := connectAs(t, user, database)
+	defer pool.Close()
+
+	store := postgres.NewEventStore(test.NewEncoder(), postgres.Pool(pool))
+	err = store.Connect(ctx)
+	if err == nil {
+		t.Fatal("Did not fail to Connect when the unique index is missing and cannot be created")
+	}
+
+	if !strings.Contains(err.Error(), `"goes_aggregate"`) || !strings.Contains(err.Error(), "CREATE UNIQUE INDEX") {
+		t.Fatalf("Connect returned unexpected error: %v", err)
+	}
+}
+
 var databaseN uint64
 
 func nextDatabase() string {
@@ -128,6 +261,47 @@ func preCreateDatabase(t *testing.T) string {
 	}
 
 	return database
+}
+
+// createRestrictedUser creates a login role that may read and write the events
+// table but has no DDL privileges, mirroring an application that connects with
+// lower permissions than the migration tooling that created the table.
+func createRestrictedUser(t *testing.T, admin *pgxpool.Pool, database string) string {
+	t.Helper()
+
+	ctx := context.Background()
+
+	user := database + "_app"
+	for _, stmt := range []string{
+		fmt.Sprintf("CREATE ROLE %s LOGIN PASSWORD 'restricted'", user),
+		fmt.Sprintf("GRANT CONNECT ON DATABASE %s TO %s", database, user),
+		fmt.Sprintf("GRANT USAGE ON SCHEMA public TO %s", user),
+		fmt.Sprintf("GRANT SELECT, INSERT, UPDATE, DELETE ON events TO %s", user),
+	} {
+		if _, err := admin.Exec(ctx, stmt); err != nil {
+			t.Fatalf("%s: %v", stmt, err)
+		}
+	}
+
+	return user
+}
+
+func connectAs(t *testing.T, user, database string) *pgxpool.Pool {
+	t.Helper()
+
+	u, err := url.Parse(os.Getenv("POSTGRES_EVENTSTORE"))
+	if err != nil {
+		t.Fatalf("parse POSTGRES_EVENTSTORE: %v", err)
+	}
+	u.User = url.UserPassword(user, "restricted")
+	u.Path = "/" + database
+
+	pool, err := pgxpool.New(context.Background(), u.String())
+	if err != nil {
+		t.Fatalf("Failed to connect to database %q as %q: %v", database, user, err)
+	}
+
+	return pool
 }
 
 func preCreateDatabaseAndTable(t *testing.T, createTableFormatString string) string {

--- a/backend/postgres/store_test.go
+++ b/backend/postgres/store_test.go
@@ -24,7 +24,34 @@ import (
 
 func TestEventStore(t *testing.T) {
 	eventstoretest.Run(t, "postgres", func(enc codec.Encoding) event.Store {
-		return postgres.NewEventStore(enc, postgres.URL(fmt.Sprintf("%s?pool_max_conn_lifetime=50ms", os.Getenv("POSTGRES_EVENTSTORE"))), postgres.Database(nextDatabase()))
+		store := postgres.NewEventStore(enc, postgres.URL(fmt.Sprintf("%s?pool_max_conn_lifetime=50ms", os.Getenv("POSTGRES_EVENTSTORE"))), postgres.Database(nextDatabase()))
+		closePoolOnCleanup(t, store)
+		return store
+	})
+}
+
+func TestEventStoreWithPool(t *testing.T) {
+	eventstoretest.Run(t, "postgres", func(enc codec.Encoding) event.Store {
+		database := preCreateDatabase(t)
+
+		pool, err := pgxpool.New(context.Background(), fmt.Sprintf("%s/%s?pool_max_conn_lifetime=50ms", os.Getenv("POSTGRES_EVENTSTORE"), database))
+		if err != nil {
+			t.Fatalf("Failed to create connection to database %q: %v", database, err)
+		}
+		t.Cleanup(pool.Close)
+
+		return postgres.NewEventStore(enc, postgres.Pool(pool))
+	})
+}
+
+// closePoolOnCleanup closes the connection pool that the store creates on
+// Connect. Without this, every factory call leaks a pool and the server
+// eventually rejects connections with "too many clients already".
+func closePoolOnCleanup(t *testing.T, store *postgres.EventStore) {
+	t.Cleanup(func() {
+		if pool := store.Pool(); pool != nil {
+			pool.Close()
+		}
 	})
 }
 
@@ -103,6 +130,67 @@ func TestConnect_ExistingTableWithInvalidSchema(t *testing.T) {
 	expectedError := `table "events" schema mismatch: missing columns: "data"; column "aggregate_id" should have type "uuid" but has type "bigint"`
 	if err.Error() != expectedError {
 		t.Fatalf("Connect returned unexpected error: %v", err)
+	}
+}
+
+func TestConnect_ExistingTableWithTextColumns(t *testing.T) {
+	database := preCreateDatabaseAndTable(t, `CREATE TABLE %s (
+		id UUID PRIMARY KEY NOT NULL,
+		name TEXT NOT NULL,
+		time BIGINT NOT NULL,
+		aggregate_id UUID,
+		aggregate_name TEXT,
+		aggregate_version INTEGER,
+		data JSONB
+	)`)
+
+	ctx := context.Background()
+
+	pool, err := pgxpool.New(ctx, fmt.Sprintf("%s/%s", os.Getenv("POSTGRES_EVENTSTORE"), database))
+	if err != nil {
+		t.Fatalf("Failed to create connection to database %q: %v", database, err)
+	}
+	defer pool.Close()
+
+	store := postgres.NewEventStore(test.NewEncoder(), postgres.Pool(pool))
+	if err := store.Connect(ctx); err != nil {
+		t.Fatalf("Failed to connect store with TEXT columns: %v", err)
+	}
+}
+
+func TestConnect_TableInUnrelatedSchema(t *testing.T) {
+	database := preCreateDatabase(t)
+
+	ctx := context.Background()
+
+	pool, err := pgxpool.New(ctx, fmt.Sprintf("%s/%s", os.Getenv("POSTGRES_EVENTSTORE"), database))
+	if err != nil {
+		t.Fatalf("Failed to create connection to database %q: %v", database, err)
+	}
+	defer pool.Close()
+
+	// A same-named table in a schema that is not on the search_path must not
+	// count as the event table: the store's queries would not resolve to it.
+	if _, err := pool.Exec(ctx, "CREATE SCHEMA other"); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	if _, err := pool.Exec(ctx, fmt.Sprintf(correctTableSQL, "other.events")); err != nil {
+		t.Fatalf("create decoy table: %v", err)
+	}
+
+	store := postgres.NewEventStore(test.NewEncoder(), postgres.Pool(pool))
+	if err := store.Connect(ctx); err != nil {
+		t.Fatalf("Failed to connect store: %v", err)
+	}
+
+	// Connect must have created the event table on the search_path instead of
+	// validating against the decoy.
+	var exists bool
+	if err := pool.QueryRow(ctx, "SELECT to_regclass('public.events') IS NOT NULL").Scan(&exists); err != nil {
+		t.Fatalf("check public.events: %v", err)
+	}
+	if !exists {
+		t.Fatal("Connect did not create the event table on the search_path")
 	}
 }
 


### PR DESCRIPTION
Brings in #341 by @ekyoung (commit cherry-picked with authorship preserved — pushing to the original PR branch wasn't possible because it lives in an org-owned fork) and adds follow-up commits addressing review findings. Closes #342.

**From #341:** `Connect` no longer runs `CREATE TABLE IF NOT EXISTS` unconditionally, which in Postgres requires the CREATE privilege on the schema even when the table already exists. Instead, the store queries the table schema: it creates the table if it is missing and validates it otherwise. This allows applications to connect with roles that may not modify the DB schema, with tables created up front by migration tooling.

**Follow-up commits:**

- `fix(postgres)`: resolve the event table through the search_path (`to_regclass`) instead of matching `information_schema.columns` by table name alone, which could validate against a same-named table in an unrelated schema and then fail at query time. Schema-qualified `Table()` names now work, `TEXT` is accepted for the `VARCHAR` columns (functionally equivalent), and validation errors are deterministic.
- `feat(postgres)`: validate the required indexes of pre-created tables. The `goes_aggregate` UNIQUE index enforces optimistic concurrency for aggregates — a pre-created table without it would silently lose that guarantee. Missing indexes are created when the connected role has the privileges (the healing behavior of previous releases); otherwise `Connect` fails with the exact DDL to run manually. Indexes are matched structurally (columns + uniqueness), not by name. The expected schema is now documented on `NewEventStore`.
- `test(postgres)`: restore the full acceptance suite for the `Pool()` option (it had been reduced to a smoke test), replace the `time.Sleep` warm-up hacks with deterministic pool cleanup via `t.Cleanup` (the sleeps were masking a connection-pool leak that exhausted `max_connections` once both suites ran), and add coverage for the restricted-role scenario this feature exists for, index healing, conflicting index names, `TEXT` columns, and a decoy table in an unrelated schema.

**Testing:** the postgres tests are not exercised by CI (no workflow exists for them); verified locally against fresh Docker Postgres 18 and 14. All `TestConnect_*` tests pass deterministically, including the original assertions from #341. `TestEventStore`/`TestEventStoreWithPool` retain a pre-existing result-ordering flake that equally affects `main`; that flake and a postgres CI workflow are being addressed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)